### PR TITLE
Implement a proper Param component

### DIFF
--- a/src/components/Param.jsx
+++ b/src/components/Param.jsx
@@ -1,5 +1,5 @@
 /*
- * Parameter.jsx - component to wrap replacement parameter values inside
+ * Param.jsx - component to wrap replacement parameter values inside
  * of a Translate component
  *
  * Copyright © 2019, JEDLSoft
@@ -44,20 +44,20 @@ export default function Param(props) {
         case 'undefined':
             ret = '';
             break;
-            
+
         case 'boolean':
         case 'number':
             ret = String(value);
             break;
-            
+
         case 'function':
             ret = value();
             break;
-            
+
         case 'string':
             ret = value;
             break;
-            
+
         case 'object':
             if (value === null) {
                 ret = '';

--- a/src/components/Param.jsx
+++ b/src/components/Param.jsx
@@ -1,0 +1,55 @@
+/*
+ * Param.jsx - component to act as a placeholder/replacement
+ * parameter inside of a Translate component body
+ *
+ * Copyright © 2019, JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from 'react';
+import Composition from '../utils/Composition';
+import PropTypes from 'prop-types';
+
+/**
+ * @class A placeholder for a replacement parameter in the body of a Translate
+ * component.
+ * 
+ * This component renders into the value of the named parameter to the Translate
+ * component. Typically, this component is self-closing.
+ * 
+ * @example
+ * <pre>
+ *   <Translate values={{filename: filelist[i].path}}>
+ *     The file <Param name="filename"/> has been deleted.
+ *   </Translate>
+ * </pre>
+ */
+class Param extends React.Component {
+    // mostly for unit testing
+    getValue() {
+        return this.props.value;
+    }
+
+    render() {
+        return <span name={this.props.name}>{this.props.value || ""}</span>;
+    }
+}
+
+Param.propTypes = {
+    "name": PropTypes.string.isRequired,
+    "value": PropTypes.any
+};
+
+export default Param;

--- a/src/components/Param.jsx
+++ b/src/components/Param.jsx
@@ -36,49 +36,48 @@ import PropTypes from 'prop-types';
  *   </Translate>
  * </pre>
  */
-class Param extends React.Component {
-    render(props) {
-        const { value, name, wrapper } = props;
-        let ret;
-        switch (typeof value) {
-            default:
-            case 'undefined':
+export default function Param(props) {
+    const { value, name, wrapper, className } = props || {};
+    let ret;
+    switch (typeof value) {
+        default:
+        case 'undefined':
+            ret = '';
+            break;
+            
+        case 'boolean':
+        case 'number':
+            ret = String(value);
+            break;
+            
+        case 'function':
+            ret = value();
+            break;
+            
+        case 'string':
+            ret = value;
+            break;
+            
+        case 'object':
+            if (value === null) {
                 ret = '';
-                break;
-    
-            case 'boolean':
-            case 'number':
-                ret = String(value);
-                break;
-    
-            case 'function':
-                ret = value();
-                break;
-    
-            case 'string':
+            } else if (React.isValidElement(value)) {
                 ret = value;
-                break;
-    
-            case 'object':
-                if (value === null) {
-                    ret = '';
-                } else if (React.isValidElement(value)) {
-                    ret = value;
-                } else {
-                    ret = value.toString();
-                }
-                break;
-        }
-    
-        if (wrapper !== null) {
-            return React.createElement(wrapper, {
-                key: name,
-                name: name,
-                className: props.className
-            }, ret);
-        } else {
-            return ret;
-        }
+            } else {
+                ret = value.toString();
+            }
+            break;
+    }
+
+    if (wrapper) {
+        const wrapperName = name || wrapper;
+        return React.createElement(wrapper, {
+            key: wrapperName,
+            name: wrapperName,
+            className: className
+        }, ret);
+    } else {
+        return ret;
     }
 };
 
@@ -98,5 +97,3 @@ Param.propTypes = {
     /** Optional: if the output is wrapped in an html tag, use this as the CSS class name */
     "className": PropTypes.string
 };
-
-export default Param;

--- a/test/components/testParam.jsx
+++ b/test/components/testParam.jsx
@@ -18,7 +18,7 @@
  */
 
 import React from 'react';
-import enzyme, { mount } from 'enzyme';
+import enzyme, { mount, render } from 'enzyme';
 import PropTypes from 'prop-types';
 import Adapter from 'enzyme-adapter-react-16';
 import Translate from '../../src/components/Translate';
@@ -31,91 +31,125 @@ function Link (props) {
 }
 
 export let testParam = {
-    testParamSimple: test => {
+    testParamString: test => {
         test.expect(1);
-
-        const wrapper = mount(
-            <Translate values={{filename: "asdf"}}>
-                The file name is <Param name="filename"/>.
-            </Translate>
+        const wrapper = render(
+            <span>
+                <Param value="asdf"/>
+            </span>,
         );
 
-        let span = wrapper.find('span');
-        test.equal(span.prop('children'), 'The file name is asdf.');
-
+        test.equal(wrapper.text(), 'asdf');
         test.done();
     },
 
-    testParamMultiple: test => {
+    testParamStringWithVariables: test => {
         test.expect(1);
-
-        const wrapper = mount(
-            <Translate values={{filename: "asdf", user: "Joe Schmoe"}}>
-                The file <Param name="filename"/> was uploaded by user "<Param name="user"/>".
-            </Translate>
+        const name = 'asdf';
+        const wrapper = render(
+            <span>
+                <Param value={name}/>
+            </span>,
         );
 
-        let span = wrapper.find('span');
-        test.equal(span.prop('children'), 'The file asdf was uploaded by user "Joe Schmoe".');
-
+        test.equal(wrapper.text(), 'asdf');
         test.done();
     },
 
-    testParamDirectValue: test => {
+    testParamNumeric: test => {
         test.expect(1);
-
-        let fname = "asdf";
-        let user = "Joe Schmoe";
-
-        const wrapper = mount(
-            <Translate>
-                The file <Param name="filename" value={fname}/> was uploaded by user "<Param name="user" value={user}/>".
-            </Translate>
+        const wrapper = render(
+            <span>
+                <Param value={3}/>
+            </span>,
         );
 
-        let span = wrapper.find('span');
-        test.equal(span.prop('children'), 'The file asdf was uploaded by user "Joe Schmoe".');
-
+        test.equal(wrapper.text(), '3');
         test.done();
     },
 
-    /*
-    testComposeSimpleContents: test => {
+    testParamUndefined: test => {
         test.expect(1);
-        const wrapper = mount(
-            <Param category="one">This is the singular</Param>,
+        const wrapper = render(
+            <span>
+                <Param value={undefined}/>
+            </span>,
         );
-        const plural = wrapper.instance();
-        test.equal(plural.getSourceString(), 'This is the singular');
+
+        test.equal(wrapper.text(), '');
         test.done();
     },
 
-    testComposeSlightlyMoreComplex: test => {
+    testParamNull: test => {
         test.expect(1);
-        const wrapper = mount(
-            <Param category="one">
-                <span className="foo">This is the singular</span>
-            </Param>,
+        const wrapper = render(
+            <span>
+                <Param value={null}/>
+            </span>,
         );
 
-        const plural = wrapper.instance();
-        test.equal(plural.getSourceString(), '<c0>This is the singular</c0>');
+        test.equal(wrapper.text(), '');
         test.done();
     },
 
-    testComposeMuchMoreComplex: test => {
+    testParamJsx: test => {
         test.expect(1);
-        const wrapper = mount(
-            <Param category="one">
-                <span className="foo">
-                    This <b>is</b> the <Link to="singular.html">singular</Link>.
-                </span>
-            </Param>,
+        const tmp = <b>foo!</b>;
+        const wrapper = render(
+            <span>
+                <Param value={tmp}/>
+            </span>,
         );
 
-        const plural = wrapper.instance();
-        test.equal(plural.getSourceString(), '<c0>This <c1>is</c1> the <c2>singular</c2>.</c0>');
+        test.equal(wrapper.html(), '<b>foo!</b>');
         test.done();
-    }
-    */
+    },
+
+    testParamFunction: test => {
+        test.expect(1);
+        const f = function f() {
+            return 'asdf';
+        };
+        const wrapper = render(
+            <span>
+                <Param value={f}/>
+            </span>,
+        );
+
+        test.equal(wrapper.text(), 'asdf');
+        test.done();
+    },
+
+    testParamStringWithDescription: test => {
+        test.expect(1);
+        const wrapper = render(
+            <span>
+                <Param value="asdf" description="foo"/>
+            </span>,
+        );
+
+        test.equal(wrapper.text(), 'asdf');
+        test.done();
+    },
+
+    testParamWithWrapper: test => {
+        test.expect(1);
+        const wrapper = render(
+            <Param wrapper="span" name="foo" value="asdf"/>
+        );
+
+        test.equal(wrapper.text(), 'asdf');
+        test.done();
+    },
+
+    testParamWithWrapperAndClass: test => {
+        test.expect(1);
+        const wrapper = render(
+            <Param wrapper="span" name="foo" className="myclass" value="asdf"/>
+        );
+
+        test.equal(wrapper.text(), 'asdf');
+        test.done();
+    },
+
 };

--- a/test/components/testParam.jsx
+++ b/test/components/testParam.jsx
@@ -1,0 +1,121 @@
+/*
+ * testParam.jsx - test the Param component.
+ *
+ * Copyright © 2019, JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import enzyme, { mount } from 'enzyme';
+import PropTypes from 'prop-types';
+import Adapter from 'enzyme-adapter-react-16';
+import Translate from '../../src/components/Translate';
+import Param from '../../src/components/Param';
+
+enzyme.configure({ adapter: new Adapter() });
+
+function Link (props) {
+    return <a href={props.to}>{props.children}</a>;
+}
+
+export let testParam = {
+    testParamSimple: test => {
+        test.expect(1);
+
+        const wrapper = mount(
+            <Translate values={{filename: "asdf"}}>
+                The file name is <Param name="filename"/>.
+            </Translate>
+        );
+
+        let span = wrapper.find('span');
+        test.equal(span.prop('children'), 'The file name is asdf.');
+
+        test.done();
+    },
+
+    testParamMultiple: test => {
+        test.expect(1);
+
+        const wrapper = mount(
+            <Translate values={{filename: "asdf", user: "Joe Schmoe"}}>
+                The file <Param name="filename"/> was uploaded by user "<Param name="user"/>".
+            </Translate>
+        );
+
+        let span = wrapper.find('span');
+        test.equal(span.prop('children'), 'The file asdf was uploaded by user "Joe Schmoe".');
+
+        test.done();
+    },
+
+    testParamDirectValue: test => {
+        test.expect(1);
+
+        let fname = "asdf";
+        let user = "Joe Schmoe";
+
+        const wrapper = mount(
+            <Translate>
+                The file <Param name="filename" value={fname}/> was uploaded by user "<Param name="user" value={user}/>".
+            </Translate>
+        );
+
+        let span = wrapper.find('span');
+        test.equal(span.prop('children'), 'The file asdf was uploaded by user "Joe Schmoe".');
+
+        test.done();
+    },
+
+    /*
+    testComposeSimpleContents: test => {
+        test.expect(1);
+        const wrapper = mount(
+            <Param category="one">This is the singular</Param>,
+        );
+        const plural = wrapper.instance();
+        test.equal(plural.getSourceString(), 'This is the singular');
+        test.done();
+    },
+
+    testComposeSlightlyMoreComplex: test => {
+        test.expect(1);
+        const wrapper = mount(
+            <Param category="one">
+                <span className="foo">This is the singular</span>
+            </Param>,
+        );
+
+        const plural = wrapper.instance();
+        test.equal(plural.getSourceString(), '<c0>This is the singular</c0>');
+        test.done();
+    },
+
+    testComposeMuchMoreComplex: test => {
+        test.expect(1);
+        const wrapper = mount(
+            <Param category="one">
+                <span className="foo">
+                    This <b>is</b> the <Link to="singular.html">singular</Link>.
+                </span>
+            </Param>,
+        );
+
+        const plural = wrapper.instance();
+        test.equal(plural.getSourceString(), '<c0>This <c1>is</c1> the <c2>singular</c2>.</c0>');
+        test.done();
+    }
+    */
+};

--- a/test/components/testSuiteFiles.js
+++ b/test/components/testSuiteFiles.js
@@ -21,5 +21,6 @@ module.exports.files = [
     "testPlural.jsx",
     "testTranslate.jsx",
     "testLocaleContext.jsx",
-    "testAddressFmt.jsx"
+    "testAddressFmt.jsx",
+    "testParam.jsx"
 ];


### PR DESCRIPTION
- Parameter changed names to Param
- Param requires a value. Does not take the value from the values prop on the Translate any more.
- Name is an optional prop that is only used when specifying a wrapper html element. If no wrapper is specified, then no wrapper is made. The value is converted into a string and that naked string is returned.
- Class name is only applicable when specifying a wrapper.